### PR TITLE
Support Cloudflare Pages deployment alongside GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,17 @@ npm run test:ui
 
 ## Hosting
 
-Designed for static hosting on platforms like Cloudflare Pages.
+Deployed via **GitHub Pages** (automatic on push to `main`) and optionally via **Cloudflare Pages** for PR preview deployments.
+
+### Cloudflare Pages Setup (Dashboard Connect)
+
+1. Go to [Cloudflare Dashboard](https://dash.cloudflare.com) → Workers & Pages → Create → Pages → Connect to Git
+2. Select this repository and configure:
+   - **Production branch:** `main`
+   - **Build command:** `npm run build`
+   - **Build output directory:** `dist`
+3. Save and deploy — Cloudflare sets `CF_PAGES=1` automatically, which tells Vite to use `/` as the base path instead of `/fragile/`
+4. Every PR will get an automatic preview URL at `<commit>.fragile.pages.dev`
 
 ---
 

--- a/tech-snapshot.md
+++ b/tech-snapshot.md
@@ -141,6 +141,10 @@ src/
 - Basic smoke tests for rendering and console output
 - Manual testing for gameplay mechanics
 
+### Deployment
+- **GitHub Pages**: Automatic via `.github/workflows/deploy.yml` on push to `main`. Uses base path `/fragile/`.
+- **Cloudflare Pages**: Dashboard-connected. Cloudflare sets `CF_PAGES=1` env var, which Vite detects to use base path `/` instead of `/fragile/`.
+
 ### Development Workflow
 ```bash
 npm run dev      # Development server

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: process.env.NODE_ENV === 'production' ? '/fragile/' : '/',
+  base: process.env.CF_PAGES ? '/' : process.env.NODE_ENV === 'production' ? '/fragile/' : '/',
   server: {
     port: 3000
   },


### PR DESCRIPTION
Detect CF_PAGES env var (set automatically by Cloudflare) to use base
path "/" instead of "/fragile/", so the same build works for both
GitHub Pages (subpath) and Cloudflare Pages (root domain). Added setup
instructions to README and deployment notes to tech-snapshot.

https://claude.ai/code/session_017R8yn9QtNV5xdf8qcprGr8