### PR TITLE
Fix zoom animation centering on settler position during settling

### DIFF
--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -200,7 +200,7 @@ export class Game {
       this.setupMobileToggles();
       this.startGameTick();
       this.saveGame();
-    });
+    }, settler.position);
 
     console.log('City founded successfully!', city);
   }

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -774,25 +774,32 @@ export class HexRenderer {
     }
   }
 
-  animateZoom(targetZoom: number, duration: number = 800, onComplete?: () => void) {
+  animateZoom(targetZoom: number, duration: number = 800, onComplete?: () => void, centerHex?: HexCoordinate) {
     if (this.isAnimating) return;
-    
+
     this.isAnimating = true;
     const startZoom = this.zoomLevel;
     const startTime = Date.now();
-    
+    const targetPixel = centerHex ? HexUtils.hexToPixel(centerHex) : null;
+
     const animate = () => {
       const elapsed = Date.now() - startTime;
       const progress = Math.min(elapsed / duration, 1);
-      
+
       // Smooth easing
       const easeProgress = 1 - Math.pow(1 - progress, 3);
-      
+
       // Interpolate zoom level
       const currentZoom = startZoom + (targetZoom - startZoom) * easeProgress;
       this.zoomLevel = currentZoom;
       this.hexContainer.scale.set(this.zoomLevel);
-      
+
+      // Keep camera centered on target hex as zoom changes
+      if (targetPixel) {
+        this.hexContainer.x = this.app.screen.width / 2 - targetPixel.x * this.zoomLevel;
+        this.hexContainer.y = this.app.screen.height / 2 - targetPixel.y * this.zoomLevel;
+      }
+
       if (progress < 1) {
         requestAnimationFrame(animate);
       } else {
@@ -800,7 +807,7 @@ export class HexRenderer {
         if (onComplete) onComplete();
       }
     };
-    
+
     requestAnimationFrame(animate);
   }
 


### PR DESCRIPTION
The animateZoom method only updated the scale but never recalculated the container position (hexContainer.x/y), causing the viewport to drift toward the container origin instead of staying centered on the settling location. Now animateZoom accepts an optional centerHex parameter and continuously updates the camera position each frame to keep the target hex centered throughout the zoom animation.

https://claude.ai/code/session_01KesspSTFxMKgEtQRLfUcX4