### PR TITLE
Improve mobile building view with compact wrapping grid

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@
 - ✅ **UI Systems**: Resource display overlay, terrain legend with production bonuses, organized left sidebar, clean UI transitions
 - ✅ **Game Systems**: Story/events system, tech tree with research mechanics (effects applied), terrain-based production bonuses
 - ✅ **Content Expansion**: 3 new buildings (granary, warehouse, hunter's lodge), 2 new techs (hunting, preservation), food consumption mechanic, tech-based building unlocks, tech effects applied to production/costs
-- ✅ **Mobile Support**: Responsive layout with toggleable sidebar overlays, touch-optimized targets, viewport zoom prevention
+- ✅ **Mobile Support**: Responsive layout with toggleable sidebar overlays, touch-optimized targets, viewport zoom prevention, compact wrapping building/research grid in bottom bar
 - ✅ **Save/Load System**: Auto-save with localStorage, title screen with New Game / Continue, versioned save format
 
 ## In Progress / Pending

--- a/tech-snapshot.md
+++ b/tech-snapshot.md
@@ -72,7 +72,7 @@
 - Handles movement logic and validation
 - Manages animation callbacks
 - Controls phase transitions (exploration → city management)
-- Mobile-responsive layout with toggleable overlay sidebars (<768px)
+- Mobile-responsive layout with toggleable overlay sidebars (<768px), compact wrapping building/research grid on mobile
 - Save/load integration with full state restoration
 
 **City Management** (`src/entities/city.ts`)


### PR DESCRIPTION
On mobile, building/research cards now use a 3-column wrapping grid
instead of a single-row horizontal scroll, so multiple buildings are
visible at once. Cards are smaller (reduced padding, fonts, min-width)
and the header text is hidden on mobile to save space. The management
bar uses auto-height (max 45vh) with vertical scroll on mobile.

https://claude.ai/code/session_0149VcMeRcTsPnmWWCLkKE1N