### PR TITLE
Add 5 tech-gated buildings and increase cost scaling

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -54,11 +54,20 @@
 ## 6 • Buildings & Tech (V1 subset)
 | Building | Prereq | Output / Effect | Base Cost | Scaling |
 |----------|--------|-----------------|-----------|---------|
-| Hut | None | +2 pop capacity. | 8 wood, 2 food | 1.10x exponential |
-| Farm | Plains adjacent | +1 food / tick (+5% per plains). | 5 wood, 2 stone | 1.15x exponential |
-| Shed | Wood storage maxed | +25 wood storage. | 10 wood | 1.08x exponential |
-| Lumber Yard | Forest adjacent | +1 wood / tick (+10% per forest). | 6 wood, 4 stone | 1.12x exponential |
-| Quarry | Hill adjacent | +1 stone / tick (+20% per hill). | 8 wood, 3 food | 1.20x exponential |
+| Hut | None | +2 pop capacity. | 8 wood, 2 food | 1.15x exponential |
+| Farm | Plains adjacent | +1 food / tick (+5% per plains). | 5 wood, 2 stone | 1.20x exponential |
+| Shed | Wood storage maxed | +25 wood storage. | 10 wood | 1.12x exponential |
+| Lumber Yard | Forest adjacent | +1 wood / tick (+10% per forest). | 6 wood, 4 stone | 1.18x exponential |
+| Quarry | Hill adjacent | +1 stone / tick (+20% per hill). | 8 wood, 3 food | 1.25x exponential |
+| Library | Population ≥ 10 | +1 research / tick. | 15 wood, 10 stone, 5 food | 1.30x exponential |
+| Granary | Food storage maxed | +20 food storage. | 12 wood, 5 stone | 1.15x exponential |
+| Warehouse | Stone storage maxed | +15 stone storage. | 15 wood, 8 stone | 1.18x exponential |
+| Hunter's Lodge | Tech "Hunting" | +1 food / tick (+10% per forest, +5% per plains). | 10 wood, 3 food | 1.20x exponential |
+| Stoneworks | Tech "Masonry" | +2 stone / tick (+20% per hill). Hill/mountain required. | 20 wood, 15 stone, 5 food | 1.30x exponential |
+| Sawmill | Tech "Advanced Tools" | +2 wood / tick (+10% per forest). Forest required. | 15 wood, 12 stone | 1.25x exponential |
+| Bakery | Tech "Crop Rotation" | +2 food / tick. | 12 wood, 10 stone | 1.25x exponential |
+| Monument | Tech "Masonry" | +5 pop capacity. | 10 wood, 30 stone, 10 food | 1.50x exponential |
+| Storehouse | Tech "Construction" | +15 food, +15 wood, +10 stone storage. | 20 wood, 15 stone | 1.20x exponential |
 | Watchtower | Tech "Defenses" | Extends city LOS; improves defense. | TBD | TBD |
 | Guard Post | None | Provides defense vs bandits/unrest (not a unit). | TBD | TBD |
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,7 @@
 - ✅ **UI Systems**: Resource display overlay, terrain legend with production bonuses, organized left sidebar, clean UI transitions
 - ✅ **Game Systems**: Story/events system, tech tree with research mechanics (effects applied), terrain-based production bonuses
 - ✅ **Content Expansion**: 3 new buildings (granary, warehouse, hunter's lodge), 2 new techs (hunting, preservation), food consumption mechanic, tech-based building unlocks, tech effects applied to production/costs
+- ✅ **Resource Gating & Balance**: 5 new tech-gated buildings (stoneworks, sawmill, bakery, monument, storehouse), deeper progression chains via research prerequisites, increased building cost scaling
 - ✅ **Mobile Support**: Responsive layout with toggleable sidebar overlays, touch-optimized targets, viewport zoom prevention, compact wrapping building/research grid in bottom bar
 - ✅ **Save/Load System**: Auto-save with localStorage, title screen with New Game / Continue, versioned save format
 

--- a/src/data/buildings.json
+++ b/src/data/buildings.json
@@ -9,7 +9,7 @@
         "food": 2
       },
       "pricing": {
-        "scalingFactor": 1.10,
+        "scalingFactor": 1.15,
         "scalingType": "exponential"
       },
       "effects": {
@@ -28,7 +28,7 @@
         "stone": 2
       },
       "pricing": {
-        "scalingFactor": 1.15,
+        "scalingFactor": 1.20,
         "scalingType": "exponential"
       },
       "effects": {
@@ -48,7 +48,7 @@
         "wood": 10
       },
       "pricing": {
-        "scalingFactor": 1.08,
+        "scalingFactor": 1.12,
         "scalingType": "exponential"
       },
       "effects": {
@@ -67,7 +67,7 @@
         "stone": 4
       },
       "pricing": {
-        "scalingFactor": 1.12,
+        "scalingFactor": 1.18,
         "scalingType": "exponential"
       },
       "effects": {
@@ -88,7 +88,7 @@
         "food": 3
       },
       "pricing": {
-        "scalingFactor": 1.20,
+        "scalingFactor": 1.25,
         "scalingType": "exponential"
       },
       "effects": {
@@ -110,7 +110,7 @@
         "food": 5
       },
       "pricing": {
-        "scalingFactor": 1.25,
+        "scalingFactor": 1.30,
         "scalingType": "exponential"
       },
       "effects": {
@@ -130,7 +130,7 @@
         "stone": 5
       },
       "pricing": {
-        "scalingFactor": 1.10,
+        "scalingFactor": 1.15,
         "scalingType": "exponential"
       },
       "effects": {
@@ -149,7 +149,7 @@
         "stone": 8
       },
       "pricing": {
-        "scalingFactor": 1.12,
+        "scalingFactor": 1.18,
         "scalingType": "exponential"
       },
       "effects": {
@@ -168,7 +168,7 @@
         "food": 3
       },
       "pricing": {
-        "scalingFactor": 1.15,
+        "scalingFactor": 1.20,
         "scalingType": "exponential"
       },
       "effects": {
@@ -179,6 +179,110 @@
       "buildTime": 2,
       "maxLevel": 3,
       "icon": "🏹"
+    },
+    "stoneworks": {
+      "id": "stoneworks",
+      "name": "Stoneworks",
+      "description": "Advanced stone cutting yields more from each quarry face",
+      "baseCost": {
+        "wood": 20,
+        "stone": 15,
+        "food": 5
+      },
+      "pricing": {
+        "scalingFactor": 1.30,
+        "scalingType": "exponential"
+      },
+      "effects": {
+        "stonePerTick": 2
+      },
+      "requiresWorker": true,
+      "requiresTerrain": ["hill", "mountain"],
+      "buildTime": 4,
+      "maxLevel": 2,
+      "icon": "🪨"
+    },
+    "sawmill": {
+      "id": "sawmill",
+      "name": "Sawmill",
+      "description": "Mechanized saws process timber far faster than hand tools",
+      "baseCost": {
+        "wood": 15,
+        "stone": 12
+      },
+      "pricing": {
+        "scalingFactor": 1.25,
+        "scalingType": "exponential"
+      },
+      "effects": {
+        "woodPerTick": 2
+      },
+      "requiresWorker": true,
+      "requiresTerrain": ["forest"],
+      "buildTime": 3,
+      "maxLevel": 2,
+      "icon": "🪚"
+    },
+    "bakery": {
+      "id": "bakery",
+      "name": "Bakery",
+      "description": "Bakers turn raw grain into nourishing bread for the settlement",
+      "baseCost": {
+        "wood": 12,
+        "stone": 10
+      },
+      "pricing": {
+        "scalingFactor": 1.25,
+        "scalingType": "exponential"
+      },
+      "effects": {
+        "foodPerTick": 2
+      },
+      "requiresWorker": true,
+      "buildTime": 3,
+      "maxLevel": 2,
+      "icon": "🍞"
+    },
+    "monument": {
+      "id": "monument",
+      "name": "Monument",
+      "description": "A grand stone monument that inspires settlers to stay and attracts newcomers",
+      "baseCost": {
+        "wood": 10,
+        "stone": 30,
+        "food": 10
+      },
+      "pricing": {
+        "scalingFactor": 1.50,
+        "scalingType": "exponential"
+      },
+      "effects": {
+        "populationCapacity": 5
+      },
+      "buildTime": 5,
+      "maxLevel": 2,
+      "icon": "🗿"
+    },
+    "storehouse": {
+      "id": "storehouse",
+      "name": "Storehouse",
+      "description": "A large well-organized building that stores all manner of goods",
+      "baseCost": {
+        "wood": 20,
+        "stone": 15
+      },
+      "pricing": {
+        "scalingFactor": 1.20,
+        "scalingType": "exponential"
+      },
+      "effects": {
+        "foodStorage": 15,
+        "woodStorage": 15,
+        "stoneStorage": 10
+      },
+      "buildTime": 3,
+      "maxLevel": 3,
+      "icon": "🏛️"
     }
   }
 }

--- a/src/data/techs.json
+++ b/src/data/techs.json
@@ -28,7 +28,8 @@
       "effects": {
         "workerEfficiency": 0.2
       },
-      "unlocks": ["specialized_tools"]
+      "unlocks": ["specialized_tools"],
+      "unlocksBuildings": ["sawmill"]
     },
     "specialized_tools": {
       "id": "specialized_tools",
@@ -73,7 +74,8 @@
       "effects": {
         "foodProduction": 0.5
       },
-      "unlocks": ["preservation"]
+      "unlocks": ["preservation"],
+      "unlocksBuildings": ["bakery"]
     },
     "preservation": {
       "id": "preservation",
@@ -119,7 +121,8 @@
       "effects": {
         "buildingCostReduction": 0.1
       },
-      "unlocks": ["masonry"]
+      "unlocks": ["masonry"],
+      "unlocksBuildings": ["storehouse"]
     },
     "masonry": {
       "id": "masonry",
@@ -135,7 +138,8 @@
         "buildingCostReduction": 0.2,
         "stoneProduction": 0.2
       },
-      "unlocks": []
+      "unlocks": [],
+      "unlocksBuildings": ["stoneworks", "monument"]
     }
   }
 }

--- a/src/entities/city.ts
+++ b/src/entities/city.ts
@@ -275,11 +275,13 @@ export class CitySystem {
       // Apply terrain bonuses based on building type
       switch (buildingType) {
         case 'lumber_yard':
+        case 'sawmill':
           if (tile.type.id === 'forest') {
             bonusMultiplier += 0.10; // +10% per forest tile
           }
           break;
         case 'quarry':
+        case 'stoneworks':
           if (tile.type.id === 'hill' || tile.type.id === 'mountain') {
             bonusMultiplier += 0.20; // +20% per hill/mountain tile
           }

--- a/src/systems/events.ts
+++ b/src/systems/events.ts
@@ -54,7 +54,12 @@ export class StorySystem {
       'library': 'Your settlement has grown into a proper community! The wisest citizens propose establishing a library to preserve knowledge and advance learning.',
       'granary': 'Food is going to waste! The elders propose building a granary to preserve your harvest and feed the growing population.',
       'warehouse': 'Stone piles are scattered everywhere. A proper warehouse would keep your building materials organized and protected.',
-      'hunters_lodge': 'Your scholars have studied the ways of the wild. Skilled hunters can now venture out to bring back game from the surrounding lands.'
+      'hunters_lodge': 'Your scholars have studied the ways of the wild. Skilled hunters can now venture out to bring back game from the surrounding lands.',
+      'stoneworks': 'Master masons have devised new techniques for cutting and shaping stone. A stoneworks will greatly increase your stone output.',
+      'sawmill': 'With advanced tools, your carpenters can now build a proper sawmill. Timber production will surge.',
+      'bakery': 'Rotating crops has yielded a surplus of grain. A bakery can turn it into bread to feed many more mouths.',
+      'monument': 'Your masons propose erecting a grand monument. Its presence would inspire settlers and attract newcomers from far away.',
+      'storehouse': 'Better construction methods allow for a large storehouse capable of holding all manner of supplies.'
     };
 
     const message = messages[buildingName] || `The settlement has discovered new construction techniques. ${buildingName} is now available to build.`;

--- a/tech-snapshot.md
+++ b/tech-snapshot.md
@@ -11,8 +11,8 @@
 - **Fog-of-war system** with visibility and exploration tracking
 - **Resource management** with food consumption (20 starting food, -1 per move)
 - **City founding mechanics** with transition from exploration to city management
-- **Building system** with 8 building types (hut, farm, shed, lumber_yard, quarry, library, granary, warehouse, hunters_lodge)
-- **Progressive building unlocks** - storage buildings unlock when respective resource is maxed, library at population 10, hunter's lodge via Hunting tech
+- **Building system** with 14 building types (hut, farm, shed, lumber_yard, quarry, library, granary, warehouse, hunters_lodge, stoneworks, sawmill, bakery, monument, storehouse)
+- **Progressive building unlocks** - storage buildings unlock when respective resource is maxed, library at population 10, tech-gated buildings (hunter's lodge via Hunting, stoneworks/monument via Masonry, sawmill via Advanced Tools, bakery via Crop Rotation, storehouse via Construction)
 - **Terrain-based production bonuses** - buildings gain efficiency from terrain within radius (includes city center)
 - **Interactive terrain legend** - shows terrain types and production bonuses during exploration phase
 - **Clean UI organization** - exploration shows food counter, city mode hides top bar and uses organized left sidebar
@@ -99,19 +99,21 @@
 **Building Configuration** (`src/data/buildings.json`)
 ```json
 {
-  "hut": { "baseCost": { "wood": 8, "food": 2 }, "effects": { "populationCapacity": 2 } },
-  "farm": { "baseCost": { "wood": 5, "stone": 2 }, "effects": { "foodPerTick": 1 }, "requiresTerrain": ["plains"] },
-  "granary": { "baseCost": { "wood": 12, "stone": 5 }, "effects": { "foodStorage": 20 } },
-  "warehouse": { "baseCost": { "wood": 15, "stone": 8 }, "effects": { "stoneStorage": 15 } },
-  "hunters_lodge": { "baseCost": { "wood": 10, "food": 3 }, "effects": { "foodPerTick": 1 }, "requiresTerrain": ["forest", "plains"] }
-  // ... etc
+  "hut": { "baseCost": { "wood": 8, "food": 2 }, "effects": { "populationCapacity": 2 }, "scaling": 1.15 },
+  "farm": { "baseCost": { "wood": 5, "stone": 2 }, "effects": { "foodPerTick": 1 }, "requiresTerrain": ["plains"], "scaling": 1.20 },
+  "stoneworks": { "baseCost": { "wood": 20, "stone": 15, "food": 5 }, "effects": { "stonePerTick": 2 }, "requiresTerrain": ["hill", "mountain"], "scaling": 1.30 },
+  "sawmill": { "baseCost": { "wood": 15, "stone": 12 }, "effects": { "woodPerTick": 2 }, "requiresTerrain": ["forest"], "scaling": 1.25 },
+  "bakery": { "baseCost": { "wood": 12, "stone": 10 }, "effects": { "foodPerTick": 2 }, "scaling": 1.25 },
+  "monument": { "baseCost": { "wood": 10, "stone": 30, "food": 10 }, "effects": { "populationCapacity": 5 }, "scaling": 1.50 },
+  "storehouse": { "baseCost": { "wood": 20, "stone": 15 }, "effects": { "foodStorage": 15, "woodStorage": 15, "stoneStorage": 10 }, "scaling": 1.20 }
+  // ... etc (14 total)
 }
 ```
 
 **Tech Configuration** (`src/data/techs.json`)
 - 9 technologies across 3 branches: Tools, Agriculture, Construction
 - Tech effects: workerEfficiency, foodProduction, stoneProduction, buildingCostReduction, foodConsumptionReduction
-- Tech-based building unlocks (e.g., Hunting tech unlocks Hunter's Lodge)
+- Tech-based building unlocks (Hunting→Hunter's Lodge, Masonry→Stoneworks/Monument, Advanced Tools→Sawmill, Crop Rotation→Bakery, Construction→Storehouse)
 
 **Procedural Generation**
 - Deterministic seeded random using coordinate hashing


### PR DESCRIPTION
New buildings with deep resource gating chains:
- Stoneworks (+2 stone/tick, needs Masonry, costs 15 stone)
- Sawmill (+2 wood/tick, needs Advanced Tools, costs 12 stone)
- Bakery (+2 food/tick, needs Crop Rotation, costs 10 stone)
- Monument (+5 pop capacity, needs Masonry, costs 30 stone)
- Storehouse (universal storage, needs Construction, costs 15 stone)

All require Library (pop 10) → prerequisite research → the tech that
unlocks them, creating multi-step progression. Stone-heavy costs force
investment in Warehouses before building them.

Building cost scaling bumped ~+0.05 across the board to slow
accumulation (e.g. Hut 1.10→1.15, Farm 1.15→1.20, Quarry 1.20→1.25).

https://claude.ai/code/session_019K4h25Ae8YRu1eMW67u5Am