### PR TITLE
Implement missing game mechanics: seasons, events, unrest, collapse, prestige

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -68,8 +68,8 @@
 | Bakery | Tech "Crop Rotation" | +2 food / tick. | 12 wood, 10 stone | 1.25x exponential |
 | Monument | Tech "Masonry" | +5 pop capacity. | 10 wood, 30 stone, 10 food | 1.50x exponential |
 | Storehouse | Tech "Construction" | +15 food, +15 wood, +10 stone storage. | 20 wood, 15 stone | 1.20x exponential |
-| Watchtower | Tech "Defenses" | Extends city LOS; improves defense. | TBD | TBD |
-| Guard Post | None | Provides defense vs bandits/unrest (not a unit). | TBD | TBD |
+| Watchtower | Tech "Defenses" | +15 defense rating per level. | 15 wood, 20 stone, 5 food | 1.30x exponential |
+| Guard Post | None | +10 defense rating per level. | 12 wood, 8 stone | 1.25x exponential |
 
 **Building Mechanics:**
 - **Scaling Costs:** Each building type uses exponential cost scaling with unique factors

--- a/TODO.md
+++ b/TODO.md
@@ -12,20 +12,24 @@
 - ✅ **Mobile Support**: Responsive layout with toggleable sidebar overlays, touch-optimized targets, viewport zoom prevention, compact wrapping building/research grid in bottom bar
 - ✅ **Save/Load System**: Auto-save with localStorage, title screen with New Game / Continue, versioned save format
 
+- ✅ **Seasons & Time**: Season system (120 ticks/year), winter food production penalty (-50%), harsh winter random event (-75%)
+- ✅ **Unrest & Integrity**: Unrest mechanics (starvation, overcrowding), integrity tracking, monument unrest reduction
+- ✅ **Dynamic Events**: Bandit raids (defense-dependent), harsh winters, civil unrest (moderate/severe), starvation warnings
+- ✅ **Defense System**: Guard post (available from start) and watchtower (Defenses tech) buildings, defense rating calculation
+- ✅ **Collapse Mechanics**: Game over when population or integrity hits 0, collapse screen with stats
+- ✅ **Legacy/Prestige System**: Relic shards earned from milestones, legacy bonuses (production, starting food, cost reduction), cross-run persistence
+- ✅ **Save Migration**: v1→v2 save format migration with backwards compatibility
+
 ## In Progress / Pending
 
-### High Priority
-- ✅ Implement save/load system with localStorage
-- ⏳ Update spec with decisions made
-
 ### Medium Priority
-- ⏳ Add dynamic events (bandit raids, harsh winters)
-- ⏳ Implement unrest and collapse mechanics
-- ⏳ Create legacy/prestige system
+- ⏳ Implement ruins generation from past runs
+- ⏳ Add legacy panel accessible mid-game (pause gameplay)
+- ⏳ Update spec with all decisions made
 
 ### Low Priority
-- ⏳ Implement guard posts and watchtowers
 - ⏳ Implement proper resource node rendering system
+- ⏳ Add hidden achievements
 - ⏳ Add small powershell script to append all docs and copy to clipboard
 
 ---

--- a/src/data/buildings.json
+++ b/src/data/buildings.json
@@ -283,6 +283,45 @@
       "buildTime": 3,
       "maxLevel": 3,
       "icon": "🏛️"
+    },
+    "guard_post": {
+      "id": "guard_post",
+      "name": "Guard Post",
+      "description": "Stationed guards defend against bandit raids and civil unrest",
+      "baseCost": {
+        "wood": 12,
+        "stone": 8
+      },
+      "pricing": {
+        "scalingFactor": 1.25,
+        "scalingType": "exponential"
+      },
+      "effects": {
+        "defenseRating": 10
+      },
+      "buildTime": 2,
+      "maxLevel": 3,
+      "icon": "🛡️"
+    },
+    "watchtower": {
+      "id": "watchtower",
+      "name": "Watchtower",
+      "description": "Elevated vantage point improves early warning and city defense",
+      "baseCost": {
+        "wood": 15,
+        "stone": 20,
+        "food": 5
+      },
+      "pricing": {
+        "scalingFactor": 1.30,
+        "scalingType": "exponential"
+      },
+      "effects": {
+        "defenseRating": 15
+      },
+      "buildTime": 4,
+      "maxLevel": 2,
+      "icon": "🗼"
     }
   }
 }

--- a/src/data/techs.json
+++ b/src/data/techs.json
@@ -140,6 +140,20 @@
       },
       "unlocks": [],
       "unlocksBuildings": ["stoneworks", "monument"]
+    },
+    "defenses": {
+      "id": "defenses",
+      "name": "Defenses",
+      "description": "Military fortifications protect against raids and threats",
+      "icon": "🏰",
+      "cost": {
+        "research": 20
+      },
+      "researchTime": 50,
+      "prerequisites": ["basic_tools"],
+      "effects": {},
+      "unlocks": [],
+      "unlocksBuildings": ["watchtower"]
     }
   }
 }

--- a/src/systems/events.ts
+++ b/src/systems/events.ts
@@ -1,7 +1,21 @@
+import { City, Season } from '../entities/city';
+
 export interface StoryMessage {
   id: string;
   text: string;
   timestamp: number;
+}
+
+export interface GameEvent {
+  type: 'bandit_raid' | 'harsh_winter' | 'civil_unrest' | 'season_change' | 'year_change' | 'starvation';
+  effects: {
+    integrityDamage?: number;
+    populationLoss?: number;
+    resourceDamage?: { resource: keyof City['resources']; amount: number }[];
+    setHarshWinter?: boolean;
+  };
+  storyId: string;
+  storyText: string;
 }
 
 export class StorySystem {
@@ -16,12 +30,12 @@ export class StorySystem {
       text,
       timestamp: Date.now()
     };
-    
+
     this.messages.push(message);
-    
+
     // Notify listeners
     this.messageCallbacks.forEach(callback => callback(message));
-    
+
     // Keep only last 50 messages to prevent memory growth
     if (this.messages.length > 50) {
       this.messages = this.messages.slice(-50);
@@ -59,7 +73,9 @@ export class StorySystem {
       'sawmill': 'With advanced tools, your carpenters can now build a proper sawmill. Timber production will surge.',
       'bakery': 'Rotating crops has yielded a surplus of grain. A bakery can turn it into bread to feed many more mouths.',
       'monument': 'Your masons propose erecting a grand monument. Its presence would inspire settlers and attract newcomers from far away.',
-      'storehouse': 'Better construction methods allow for a large storehouse capable of holding all manner of supplies.'
+      'storehouse': 'Better construction methods allow for a large storehouse capable of holding all manner of supplies.',
+      'watchtower': 'Your engineers can now build watchtowers. These elevated fortifications provide early warning and improved defense.',
+      'guard_post': 'Guards can now be stationed around the settlement to defend against threats.'
     };
 
     const message = messages[buildingName] || `The settlement has discovered new construction techniques. ${buildingName} is now available to build.`;
@@ -76,7 +92,8 @@ export class StorySystem {
       'preservation': 'Salt curing and smoking techniques reduce food waste. Your stores last longer through the seasons.',
       'hunting': 'Organized hunting parties can now track and harvest wild game reliably. The forest provides.',
       'construction': 'New building methods reduce material waste. Construction costs have decreased.',
-      'masonry': 'Stone walls rise faster and stronger than ever. Your masons have truly mastered their craft.'
+      'masonry': 'Stone walls rise faster and stronger than ever. Your masons have truly mastered their craft.',
+      'defenses': 'Military knowledge allows construction of fortified positions. The settlement can now defend itself.'
     };
 
     const message = messages[techId] || `Research into ${techName} has been completed, unlocking new possibilities for the settlement.`;
@@ -98,6 +115,113 @@ export class StorySystem {
       this.addMessage('pop_5', 'Word of your thriving community spreads. More settlers arrive, bringing skills and hope for the future.');
     } else if (newPopulation === 10) {
       this.addMessage('pop_10', 'Your settlement has grown into a proper village! The increased population brings new opportunities and challenges.');
+    } else if (newPopulation === 15) {
+      this.addMessage('pop_15', 'Your village has grown into a small town. The challenges of managing so many souls weigh heavily.');
+    } else if (newPopulation === 20) {
+      this.addMessage('pop_20', 'Twenty souls now call this place home. A proper town council has formed to help govern.');
     }
+  }
+}
+
+// Event generation system - checks conditions and returns events to apply
+export class EventSystem {
+  private lastBanditRaidTick: number = 0;
+  private banditRaidCooldown: number = 30; // minimum ticks between raids
+
+  checkForEvents(city: City, season: Season, isHarshWinter: boolean): GameEvent[] {
+    const events: GameEvent[] = [];
+
+    // Harsh winter check (10% chance per winter tick if not already harsh)
+    if (season === 'winter' && !isHarshWinter) {
+      // Only trigger at the start of winter (first tick)
+      const winterStartTick = Math.floor(city.tickCount / 30) * 30;
+      if (city.tickCount === winterStartTick && Math.random() < 0.25) {
+        events.push({
+          type: 'harsh_winter',
+          effects: { setHarshWinter: true },
+          storyId: 'event_harsh_winter',
+          storyText: 'A brutal cold front sweeps across the land. This winter is far harsher than expected — food production will be severely reduced.'
+        });
+      }
+    }
+
+    // Bandit raid check (starts after tick 60, more frequent as city grows)
+    if (city.tickCount > 60 && city.tickCount - this.lastBanditRaidTick >= this.banditRaidCooldown) {
+      const raidChance = Math.min(0.08, 0.02 + city.population * 0.003);
+      if (Math.random() < raidChance) {
+        this.lastBanditRaidTick = city.tickCount;
+        const defense = city.defenseRating;
+        const raidStrength = Math.floor(5 + city.tickCount / 30);
+
+        if (defense >= raidStrength) {
+          // Defended successfully
+          events.push({
+            type: 'bandit_raid',
+            effects: {},
+            storyId: 'event_bandit_raid_defended',
+            storyText: 'Bandits approached the settlement, but your guards drove them away. The defenses held firm.'
+          });
+        } else {
+          // Raid damages the city
+          const damage = Math.max(1, raidStrength - defense);
+          const integrityLoss = Math.min(15, damage * 2);
+          const foodLoss = Math.min(city.resources.food, Math.floor(damage * 1.5));
+          const woodLoss = Math.min(city.resources.wood, damage);
+
+          events.push({
+            type: 'bandit_raid',
+            effects: {
+              integrityDamage: integrityLoss,
+              resourceDamage: [
+                { resource: 'food', amount: foodLoss },
+                { resource: 'wood', amount: woodLoss }
+              ]
+            },
+            storyId: 'event_bandit_raid',
+            storyText: defense > 0
+              ? `Bandits raided the settlement! Your guards fought bravely but were overwhelmed. They stole food and wood, and damaged buildings. (-${integrityLoss} integrity)`
+              : `Bandits raided the undefended settlement! They pillaged food and building materials, leaving destruction in their wake. Build guard posts to defend! (-${integrityLoss} integrity)`
+          });
+        }
+      }
+    }
+
+    // Civil unrest check (when unrest > 70)
+    if (city.unrest > 70) {
+      const unrestChance = (city.unrest - 70) / 100; // 0-30% chance based on unrest level
+      if (Math.random() < unrestChance) {
+        const severity = city.unrest > 90 ? 'severe' : 'moderate';
+        if (severity === 'severe') {
+          events.push({
+            type: 'civil_unrest',
+            effects: {
+              integrityDamage: 10,
+              populationLoss: 1
+            },
+            storyId: 'event_civil_unrest_severe',
+            storyText: 'Riots have broken out! Desperate citizens clash in the streets. Some have fled, and buildings were damaged in the chaos. (-10 integrity, -1 population)'
+          });
+        } else {
+          events.push({
+            type: 'civil_unrest',
+            effects: {
+              integrityDamage: 5
+            },
+            storyId: 'event_civil_unrest',
+            storyText: 'Discontent spreads through the settlement. Angry citizens damage property in protest. Address their grievances before it escalates! (-5 integrity)'
+          });
+        }
+      }
+    }
+
+    return events;
+  }
+
+  exportState(): { lastBanditRaidTick: number } {
+    return { lastBanditRaidTick: this.lastBanditRaidTick };
+  }
+
+  importState(data: { lastBanditRaidTick: number }): void {
+    this.lastBanditRaidTick = data.lastBanditRaidTick;
   }
 }

--- a/src/systems/prestige.ts
+++ b/src/systems/prestige.ts
@@ -1,0 +1,155 @@
+import { City } from '../entities/city';
+
+const LEGACY_KEY = 'fragile_legacy';
+
+export interface LegacyRun {
+  cityName: string;
+  population: number;
+  ticksSurvived: number;
+  wintersSurvived: number;
+  techsResearched: number;
+  buildingsBuilt: number;
+  collapseReason: string;
+  relicShardsEarned: number;
+  timestamp: number;
+}
+
+export interface LegacyData {
+  totalRelicShards: number;
+  runs: LegacyRun[];
+  bonuses: {
+    productionBonus: number;   // % bonus to all production
+    startingFood: number;      // extra starting food
+    buildingCostReduction: number; // % reduction
+  };
+}
+
+export class PrestigeSystem {
+  private legacyData: LegacyData;
+
+  constructor() {
+    this.legacyData = this.loadLegacy();
+  }
+
+  private loadLegacy(): LegacyData {
+    try {
+      const json = localStorage.getItem(LEGACY_KEY);
+      if (json) {
+        return JSON.parse(json);
+      }
+    } catch (e) {
+      console.error('Failed to load legacy data:', e);
+    }
+    return {
+      totalRelicShards: 0,
+      runs: [],
+      bonuses: {
+        productionBonus: 0,
+        startingFood: 0,
+        buildingCostReduction: 0
+      }
+    };
+  }
+
+  private saveLegacy(): void {
+    try {
+      localStorage.setItem(LEGACY_KEY, JSON.stringify(this.legacyData));
+    } catch (e) {
+      console.error('Failed to save legacy data:', e);
+    }
+  }
+
+  calculateRelicShards(city: City, techsResearched: number): number {
+    let shards = 0;
+
+    // Techs researched: 2 shards each
+    shards += techsResearched * 2;
+
+    // Winters survived: 3 shards each
+    shards += city.wintersSurvived * 3;
+
+    // Population milestones
+    if (city.population >= 5) shards += 2;
+    if (city.population >= 10) shards += 3;
+    if (city.population >= 15) shards += 5;
+    if (city.population >= 20) shards += 8;
+
+    // Survival duration: 1 shard per 60 ticks
+    shards += Math.floor(city.tickCount / 60);
+
+    // Building count bonus
+    const buildingCount = city.buildings.length - 1; // exclude town hall
+    if (buildingCount >= 5) shards += 2;
+    if (buildingCount >= 10) shards += 3;
+    if (buildingCount >= 15) shards += 5;
+
+    return shards;
+  }
+
+  recordCollapse(city: City, techsResearched: number, collapseReason: string): LegacyRun {
+    const shards = this.calculateRelicShards(city, techsResearched);
+
+    const run: LegacyRun = {
+      cityName: city.name,
+      population: city.population,
+      ticksSurvived: city.tickCount,
+      wintersSurvived: city.wintersSurvived,
+      techsResearched,
+      buildingsBuilt: city.buildings.length - 1,
+      collapseReason,
+      relicShardsEarned: shards,
+      timestamp: Date.now()
+    };
+
+    this.legacyData.runs.push(run);
+    this.legacyData.totalRelicShards += shards;
+
+    // Recalculate bonuses based on total shards (capped at 20% per spec)
+    this.recalculateBonuses();
+    this.saveLegacy();
+
+    return run;
+  }
+
+  private recalculateBonuses(): void {
+    const shards = this.legacyData.totalRelicShards;
+
+    // Production bonus: +1% per 5 shards, capped at 20%
+    this.legacyData.bonuses.productionBonus = Math.min(0.20, Math.floor(shards / 5) * 0.01);
+
+    // Starting food: +2 per 10 shards, capped at 20
+    this.legacyData.bonuses.startingFood = Math.min(20, Math.floor(shards / 10) * 2);
+
+    // Building cost reduction: +1% per 8 shards, capped at 10%
+    this.legacyData.bonuses.buildingCostReduction = Math.min(0.10, Math.floor(shards / 8) * 0.01);
+  }
+
+  getLegacyData(): LegacyData {
+    return { ...this.legacyData, runs: [...this.legacyData.runs] };
+  }
+
+  getBonuses(): LegacyData['bonuses'] {
+    return { ...this.legacyData.bonuses };
+  }
+
+  getTotalShards(): number {
+    return this.legacyData.totalRelicShards;
+  }
+
+  getRunCount(): number {
+    return this.legacyData.runs.length;
+  }
+
+  resetLegacy(): void {
+    this.legacyData = {
+      totalRelicShards: 0,
+      runs: [],
+      bonuses: {
+        productionBonus: 0,
+        startingFood: 0,
+        buildingCostReduction: 0
+      }
+    };
+    this.saveLegacy();
+  }
+}

--- a/tech-snapshot.md
+++ b/tech-snapshot.md
@@ -1,7 +1,7 @@
 # Fragile - Technical Snapshot
 
-*Version: Pre-Alpha - Basic Exploration*  
-*Date: 2025-06-16*
+*Version: Alpha - Full Mechanics*
+*Date: 2026-02-11*
 
 ## Current Features
 
@@ -11,11 +11,17 @@
 - **Fog-of-war system** with visibility and exploration tracking
 - **Resource management** with food consumption (20 starting food, -1 per move)
 - **City founding mechanics** with transition from exploration to city management
-- **Building system** with 14 building types (hut, farm, shed, lumber_yard, quarry, library, granary, warehouse, hunters_lodge, stoneworks, sawmill, bakery, monument, storehouse)
-- **Progressive building unlocks** - storage buildings unlock when respective resource is maxed, library at population 10, tech-gated buildings (hunter's lodge via Hunting, stoneworks/monument via Masonry, sawmill via Advanced Tools, bakery via Crop Rotation, storehouse via Construction)
+- **Building system** with 16 building types (hut, farm, shed, lumber_yard, quarry, library, granary, warehouse, hunters_lodge, stoneworks, sawmill, bakery, monument, storehouse, guard_post, watchtower)
+- **Progressive building unlocks** - storage buildings unlock when respective resource is maxed, library at population 10, guard_post from start, tech-gated buildings (hunter's lodge via Hunting, stoneworks/monument via Masonry, sawmill via Advanced Tools, bakery via Crop Rotation, storehouse via Construction, watchtower via Defenses)
 - **Terrain-based production bonuses** - buildings gain efficiency from terrain within radius (includes city center)
+- **Seasons system** - 120 ticks/year, 4 seasons (Spring/Summer/Autumn/Winter), Winter reduces food production by 50%, harsh winter random event reduces by 75%
+- **Unrest & integrity mechanics** - Starvation and overcrowding increase unrest, monuments reduce unrest, >70% unrest triggers civil unrest events, integrity tracks city structural health
+- **Dynamic events** - Bandit raids (defense-dependent damage), harsh winters, civil unrest (moderate/severe), starvation warnings
+- **Defense system** - Guard posts and watchtowers provide defense rating, raids compare against defense to determine outcome
+- **Collapse mechanics** - Game over when population or integrity hits 0, shows collapse screen with stats and legacy rewards
+- **Legacy/prestige system** - Relic shards earned from techs, winters survived, milestones; cross-run bonuses (production, starting food, building costs)
 - **Interactive terrain legend** - shows terrain types and production bonuses during exploration phase
-- **Clean UI organization** - exploration shows food counter, city mode hides top bar and uses organized left sidebar
+- **Clean UI organization** - exploration shows food counter, city mode shows season/year bar, integrity/unrest/defense stats, organized left sidebar
 - **Worker assignment** and resource production systems
 - **Scaling costs** with exponential pricing for building upgrades
 - **Smooth movement animations** (300ms with easing)
@@ -111,9 +117,9 @@
 ```
 
 **Tech Configuration** (`src/data/techs.json`)
-- 9 technologies across 3 branches: Tools, Agriculture, Construction
+- 10 technologies across 4 branches: Tools, Agriculture, Construction, Defenses
 - Tech effects: workerEfficiency, foodProduction, stoneProduction, buildingCostReduction, foodConsumptionReduction
-- Tech-based building unlocks (Hunting→Hunter's Lodge, Masonry→Stoneworks/Monument, Advanced Tools→Sawmill, Crop Rotation→Bakery, Construction→Storehouse)
+- Tech-based building unlocks (Hunting→Hunter's Lodge, Masonry→Stoneworks/Monument, Advanced Tools→Sawmill, Crop Rotation→Bakery, Construction→Storehouse, Defenses→Watchtower)
 
 **Procedural Generation**
 - Deterministic seeded random using coordinate hashing
@@ -149,7 +155,10 @@ src/
 ├── systems/        # Game systems
 │   ├── input.ts    # Mouse input handling
 │   ├── visibility.ts # Fog-of-war system
-│   └── worldgen.ts # Procedural world generation
+│   ├── worldgen.ts # Procedural world generation
+│   ├── events.ts   # Story messages + dynamic event system
+│   ├── tech.ts     # Technology research system
+│   └── prestige.ts # Legacy/prestige cross-run system
 ├── data/           # Configuration
 │   ├── tiles.json  # Tile and resource definitions
 │   └── buildings.json # Building configurations
@@ -198,15 +207,16 @@ npm run test     # Run Playwright tests
 
 ## Known Limitations
 
-1. **No dynamic events** - No bandit raids, harsh winters, or unrest mechanics
-2. **Memory growth** - Generated tiles never cleaned up
-3. **Ore/fish unused** - Defined in tiles but not yet consumed by any building or mechanic
+1. **Memory growth** - Generated tiles never cleaned up
+2. **Ore/fish unused** - Defined in tiles but not yet consumed by any building or mechanic
+3. **No ruins generation** - Past run ruins not yet placed on new maps
+4. **No mid-game legacy panel** - Legacy data only shown on collapse
 
 ## Next Planned Features
-1. Implement unrest and collapse mechanics
-2. Add dynamic events (bandit raids, harsh winters)
-3. Create legacy/prestige system
-4. Add more content (buildings using ore, defense buildings)
+1. Implement ruins generation from past civilizations
+2. Add mid-game legacy panel access
+3. Add hidden achievements
+4. Add more content (buildings using ore, fish mechanics)
 
 ---
 


### PR DESCRIPTION
- Add season system (120 ticks/year, 4 seasons with winter food penalties)
- Add unrest mechanics (starvation/overcrowding increases, monuments reduce)
- Add dynamic events: bandit raids, harsh winters, civil unrest
- Add defense buildings (guard post, watchtower) and Defenses tech
- Add collapse mechanics with game-over screen when pop/integrity hits 0
- Add legacy/prestige system with relic shards and cross-run bonuses
- Update save system to v2 with backwards-compatible v1 migration
- Update UI sidebar with season/year display, unrest bar, defense rating

https://claude.ai/code/session_01BfbJUsYk1FQiY74iTRRvtj