### PR TITLE
Implement ruins generation from past collapsed cities

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,11 +19,11 @@
 - ✅ **Collapse Mechanics**: Game over when population or integrity hits 0, collapse screen with stats
 - ✅ **Legacy/Prestige System**: Relic shards earned from milestones, legacy bonuses (production, starting food, cost reduction), cross-run persistence
 - ✅ **Save Migration**: v1→v2 save format migration with backwards compatibility
+- ✅ **Ruins from Past Runs**: Collapsed cities become ruins tiles on future maps with unique visuals, +3 food bonus on discovery, story messages, backwards-compatible legacy data migration
 
 ## In Progress / Pending
 
 ### Medium Priority
-- ⏳ Implement ruins generation from past runs
 - ⏳ Add legacy panel accessible mid-game (pause gameplay)
 - ⏳ Update spec with all decisions made
 

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -100,7 +100,8 @@ export class HexRenderer {
       { name: 'Hills', color: 0xDAA520, bonus: '+20% stone', y: 135 },
       { name: 'Mountain', color: 0x708090, bonus: '+20% stone', y: 160 },
       { name: 'River', color: 0x00BFFF, bonus: 'water source', y: 185 },
-      { name: 'Lake', color: 0x1E90FF, bonus: 'water source', y: 210 }
+      { name: 'Lake', color: 0x1E90FF, bonus: 'water source', y: 210 },
+      { name: 'Ruins', color: 0x8B7355, bonus: 'past civ', y: 235 }
     ];
 
     terrainInfo.forEach(terrain => {
@@ -496,6 +497,34 @@ export class HexRenderer {
           graphics.moveTo(startX, startY);
           graphics.lineTo(endX, endY);
         }
+        break;
+
+      case 'ruins':
+        // Crumbled walls and stone fragments
+        const stoneColor = this.lightenColor(baseColor, 0.3);
+        const darkStone = this.darkenColor(baseColor, 0.3);
+        graphics.lineStyle(0);
+
+        // Broken wall segments
+        graphics.beginFill(stoneColor);
+        graphics.drawRect(x - size * 0.5, y - size * 0.1, size * 0.3, size * 0.15);
+        graphics.drawRect(x + size * 0.15, y - size * 0.3, size * 0.15, size * 0.35);
+        graphics.drawRect(x - size * 0.2, y + size * 0.1, size * 0.45, size * 0.12);
+        graphics.endFill();
+
+        // Scattered rubble dots
+        graphics.beginFill(darkStone);
+        for (let i = 0; i < 6; i++) {
+          const angle = (Math.PI * 2 * i) / 6 + 0.5;
+          const radius = size * (0.2 + Math.sin(i * 2.1) * 0.15);
+          graphics.drawCircle(x + Math.cos(angle) * radius, y + Math.sin(angle) * radius, 2);
+        }
+        graphics.endFill();
+
+        // Faint golden glow in center (relic energy)
+        graphics.beginFill(0xFFD700, 0.15);
+        graphics.drawCircle(x, y, size * 0.25);
+        graphics.endFill();
         break;
     }
   }

--- a/src/data/tiles.json
+++ b/src/data/tiles.json
@@ -37,10 +37,17 @@
     },
     "lake": {
       "id": "lake",
-      "name": "Lake", 
+      "name": "Lake",
       "color": "#1E90FF",
       "resources": ["fish"],
       "weight": 2
+    },
+    "ruins": {
+      "id": "ruins",
+      "name": "Ruins",
+      "color": "#8B7355",
+      "resources": ["stone"],
+      "weight": 0
     }
   },
   

--- a/tech-snapshot.md
+++ b/tech-snapshot.md
@@ -7,7 +7,7 @@
 
 ### Core Gameplay
 - **Settler exploration** with click-to-move mechanics
-- **Procedural world generation** with 6 tile types, 5 resource types, and adaptive terrain clustering
+- **Procedural world generation** with 7 tile types (including ruins), 5 resource types, and adaptive terrain clustering
 - **Fog-of-war system** with visibility and exploration tracking
 - **Resource management** with food consumption (20 starting food, -1 per move)
 - **City founding mechanics** with transition from exploration to city management
@@ -19,7 +19,8 @@
 - **Dynamic events** - Bandit raids (defense-dependent damage), harsh winters, civil unrest (moderate/severe), starvation warnings
 - **Defense system** - Guard posts and watchtowers provide defense rating, raids compare against defense to determine outcome
 - **Collapse mechanics** - Game over when population or integrity hits 0, shows collapse screen with stats and legacy rewards
-- **Legacy/prestige system** - Relic shards earned from techs, winters survived, milestones; cross-run bonuses (production, starting food, building costs)
+- **Legacy/prestige system** - Relic shards earned from techs, winters survived, milestones; cross-run bonuses (production, starting food, building costs); collapsed cities become ruins tiles on future maps
+- **Ruins generation** - Past cities persist as ruins tiles with unique visuals (crumbled walls, golden glow), discoverable during exploration for +3 food bonus and story messages
 - **Interactive terrain legend** - shows terrain types and production bonuses during exploration phase
 - **Clean UI organization** - exploration shows food counter, city mode shows season/year bar, integrity/unrest/defense stats, organized left sidebar
 - **Worker assignment** and resource production systems
@@ -98,7 +99,8 @@
 {
   "plains": { "color": "#9ACD32", "resources": ["wild_game"], "weight": 40 },
   "forest": { "color": "#228B22", "resources": ["wood"], "weight": 25 },
-  // ... etc
+  "ruins": { "color": "#8B7355", "resources": ["stone"], "weight": 0 },
+  // ... etc (7 tile types)
 }
 ```
 
@@ -209,14 +211,12 @@ npm run test     # Run Playwright tests
 
 1. **Memory growth** - Generated tiles never cleaned up
 2. **Ore/fish unused** - Defined in tiles but not yet consumed by any building or mechanic
-3. **No ruins generation** - Past run ruins not yet placed on new maps
-4. **No mid-game legacy panel** - Legacy data only shown on collapse
+3. **No mid-game legacy panel** - Legacy data only shown on collapse
 
 ## Next Planned Features
-1. Implement ruins generation from past civilizations
-2. Add mid-game legacy panel access
-3. Add hidden achievements
-4. Add more content (buildings using ore, fish mechanics)
+1. Add mid-game legacy panel access
+2. Add hidden achievements
+3. Add more content (buildings using ore, fish mechanics)
 
 ---
 


### PR DESCRIPTION
Collapsed cities now persist as ruins tiles on future maps, fulfilling
the "Legacy Across Ruins" design pillar from the spec. Ruins appear at
the exact location of past cities with unique crumbled-wall visuals and
a golden glow. When a settler discovers ruins, they receive +3 food and
a story message naming the fallen civilization.

- Add LegacyRuin type and ruins array to prestige system with migration
- Add ruins tile type (weight 0, stone resource, brown color)
- WorldGenerator accepts ruin locations and overrides tile generation
- Renderer draws crumbled walls, rubble, and faint golden glow for ruins
- Settler gets +3 food bonus + story message on ruins discovery
- Backwards-compatible: old legacy data auto-migrates to include ruins

https://claude.ai/code/session_01RLQPQsW934pWo6Pgpkz9YX